### PR TITLE
Add upfront path validation to match fast-redact behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -296,12 +296,12 @@ function validatePath (path) {
   }
 
   if (path === '') {
-    throw new Error('Invalid path ()')
+    throw new Error('Invalid redaction path ()')
   }
 
   // Check for double dots
   if (path.includes('..')) {
-    throw new Error(`Invalid path (${path})`)
+    throw new Error(`Invalid redaction path (${path})`)
   }
 
   // Check for unmatched brackets
@@ -325,13 +325,13 @@ function validatePath (path) {
     } else if (char === ']' && !inQuotes) {
       bracketCount--
       if (bracketCount < 0) {
-        throw new Error(`Invalid path (${path})`)
+        throw new Error(`Invalid redaction path (${path})`)
       }
     }
   }
 
   if (bracketCount !== 0) {
-    throw new Error(`Invalid path (${path})`)
+    throw new Error(`Invalid redaction path (${path})`)
   }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -298,7 +298,7 @@ test('path validation - empty string should throw', () => {
   assert.throws(() => {
     slowRedact({ paths: [''] })
   }, {
-    message: 'Invalid path ()'
+    message: 'Invalid redaction path ()'
   })
 })
 
@@ -306,13 +306,13 @@ test('path validation - double dots should throw', () => {
   assert.throws(() => {
     slowRedact({ paths: ['invalid..path'] })
   }, {
-    message: 'Invalid path (invalid..path)'
+    message: 'Invalid redaction path (invalid..path)'
   })
 
   assert.throws(() => {
     slowRedact({ paths: ['a..b..c'] })
   }, {
-    message: 'Invalid path (a..b..c)'
+    message: 'Invalid redaction path (a..b..c)'
   })
 })
 
@@ -320,19 +320,19 @@ test('path validation - unmatched brackets should throw', () => {
   assert.throws(() => {
     slowRedact({ paths: ['invalid[unclosed'] })
   }, {
-    message: 'Invalid path (invalid[unclosed)'
+    message: 'Invalid redaction path (invalid[unclosed)'
   })
 
   assert.throws(() => {
     slowRedact({ paths: ['invalid]unopened'] })
   }, {
-    message: 'Invalid path (invalid]unopened)'
+    message: 'Invalid redaction path (invalid]unopened)'
   })
 
   assert.throws(() => {
     slowRedact({ paths: ['nested[a[b]'] })
   }, {
-    message: 'Invalid path (nested[a[b])'
+    message: 'Invalid redaction path (nested[a[b])'
   })
 })
 
@@ -346,7 +346,7 @@ test('path validation - mixed valid and invalid should throw', () => {
   assert.throws(() => {
     slowRedact({ paths: ['valid.path', 'invalid..path'] })
   }, {
-    message: 'Invalid path (invalid..path)'
+    message: 'Invalid redaction path (invalid..path)'
   })
 })
 


### PR DESCRIPTION
## Summary

- Add path validation during redactor initialization that validates all paths are strings (non-empty)
- Check for valid path syntax (no double dots, matched brackets)  
- Throw appropriate errors for invalid redaction paths
- Add comprehensive tests for path validation
- Maintain backward compatibility for valid paths

## Test plan

- [x] All existing tests continue to pass
- [x] New path validation tests cover invalid inputs (non-strings, empty strings, double dots, unmatched brackets)
- [x] Valid path patterns continue to work correctly
- [x] Error messages are descriptive and consistent

Fixes #4

🤖 Generated with [Claude Code](https://claude.ai/code)