### PR TITLE
Fix censor function signature to match fast-redact compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ function redactPaths (obj, paths, censor) {
       redactWildcardPath(obj, parts, censor, path)
     } else {
       const actualCensor = typeof censor === 'function'
-        ? censor(getValue(obj, parts), path)
+        ? censor(getValue(obj, parts), parts)
         : censor
       setValue(obj, parts, actualCensor)
     }
@@ -163,15 +163,17 @@ function redactWildcardPath (obj, parts, censor, originalPath) {
 
     if (Array.isArray(current)) {
       for (let i = 0; i < current.length; i++) {
+        const indexPath = [...parentParts, i.toString()]
         const actualCensor = typeof censor === 'function'
-          ? censor(current[i], `${originalPath.replace('*', i)}`)
+          ? censor(current[i], indexPath)
           : censor
         current[i] = actualCensor
       }
     } else if (typeof current === 'object' && current !== null) {
       for (const key in current) {
+        const keyPath = [...parentParts, key]
         const actualCensor = typeof censor === 'function'
-          ? censor(current[key], `${originalPath.replace('*', key)}`)
+          ? censor(current[key], keyPath)
           : censor
         current[key] = actualCensor
       }
@@ -207,8 +209,9 @@ function redactIntermediateWildcard (obj, parts, censor, wildcardIndex, original
         traverse(current[nextKey], pathLength + 1)
       }
     } else {
+      const fullPath = [...pathArray.slice(0, pathLength), ...afterWildcard]
       const actualCensor = typeof censor === 'function'
-        ? censor(getValue(current, afterWildcard), pathArray.slice(0, pathLength).join('.') + '.' + afterWildcard.join('.'))
+        ? censor(getValue(current, afterWildcard), fullPath)
         : censor
       setValue(current, afterWildcard, actualCensor)
     }


### PR DESCRIPTION
## Summary

Fixes the censor function signature incompatibility with fast-redact by changing the path parameter from a string to an array, ensuring drop-in replacement compatibility.

## Problem Solved

- **Issue**: Censor functions received path as string instead of array, breaking compatibility with fast-redact
- **Impact**: Prevented slow-redact from being used as a drop-in replacement for fast-redact
- **Affected**: Libraries like pino that use custom censor functions

## Changes Made

### Core Implementation
- **Regular paths**: Updated to pass `parts` array instead of `path` string (index.js:143)
- **Wildcard arrays**: Now passes `[...parentParts, i.toString()]` (index.js:167) 
- **Wildcard objects**: Now passes `[...parentParts, key]` (index.js:174)
- **Intermediate wildcards**: Now passes `[...pathArray.slice(0, pathLength), ...afterWildcard]` (index.js:211)

### Test Updates
- Updated existing censor function test to handle array paths properly
- Added 5 comprehensive compatibility tests covering:
  - Basic path arrays with bracket notation
  - Nested paths returning correct arrays  
  - Wildcard patterns with arrays
  - Array wildcards returning string indices
  - End wildcards with object keys

## Breaking Change Notice

⚠️ **BREAKING CHANGE**: This modifies the censor function signature from:
```javascript
// Before (incompatible)
censor(value, pathString)

// After (fast-redact compatible) 
censor(value, pathArray)
```

## Fast-Redact Compatibility

Now supports censor functions written for fast-redact:
```javascript
const customCensor = (value, path) => {
  console.log('Path type:', Array.isArray(path)); // Now: true
  console.log('Path:', path); // Now: ['headers', 'authorization'] 
  return '[REDACTED]';
};
```

## Testing

- ✅ All 57 tests pass
- ✅ ESLint passes without errors  
- ✅ Added comprehensive compatibility test suite
- ✅ Verified with various path patterns (nested, wildcards, arrays)

## Compatibility Impact

This change enables:
1. **Drop-in replacement**: Existing fast-redact censor functions work seamlessly
2. **Pino compatibility**: Resolves blocking issues for pino library adoption
3. **Ecosystem migration**: Easier transition from fast-redact to slow-redact

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/code)