### PR TITLE
Fix path validation for comma-separated paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -318,6 +318,11 @@ function validatePath (path) {
     throw new Error(`Invalid redaction path (${path})`)
   }
 
+  // Check for comma-separated paths (invalid syntax)
+  if (path.includes(',')) {
+    throw new Error(`Invalid redaction path (${path})`)
+  }
+
   // Check for unmatched brackets
   let bracketCount = 0
   let inQuotes = false

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -336,6 +336,26 @@ test('path validation - unmatched brackets should throw', () => {
   })
 })
 
+test('path validation - comma-separated paths should throw', () => {
+  assert.throws(() => {
+    slowRedact({ paths: ['req,headers.cookie'] })
+  }, {
+    message: 'Invalid redaction path (req,headers.cookie)'
+  })
+
+  assert.throws(() => {
+    slowRedact({ paths: ['user,profile,name'] })
+  }, {
+    message: 'Invalid redaction path (user,profile,name)'
+  })
+
+  assert.throws(() => {
+    slowRedact({ paths: ['a,b'] })
+  }, {
+    message: 'Invalid redaction path (a,b)'
+  })
+})
+
 test('path validation - mixed valid and invalid should throw', () => {
   assert.throws(() => {
     slowRedact({ paths: ['valid.path', 123, 'another.valid'] })
@@ -347,6 +367,12 @@ test('path validation - mixed valid and invalid should throw', () => {
     slowRedact({ paths: ['valid.path', 'invalid..path'] })
   }, {
     message: 'Invalid redaction path (invalid..path)'
+  })
+
+  assert.throws(() => {
+    slowRedact({ paths: ['valid.path', 'req,headers.cookie'] })
+  }, {
+    message: 'Invalid redaction path (req,headers.cookie)'
   })
 })
 


### PR DESCRIPTION
## Summary

Fixes #10 by adding proper validation to reject comma-separated path syntax like `'req,headers.cookie'` to match fast-redact compatibility.

## Problem

slow-redact was incorrectly accepting invalid path syntax that should be rejected for fast-redact compatibility. Specifically, paths with comma-separated syntax like `'req,headers.cookie'` were being accepted when they should throw an error.

## Changes

- ✅ Add comma validation in `validatePath()` function (`index.js:321-324`)
- ✅ Add comprehensive test cases for comma-separated path validation 
- ✅ Ensure consistent error message format: `"Invalid redaction path (path)"`
- ✅ All 58 tests pass

## Test Results

**Before fix:**
```javascript
// This incorrectly succeeded without error
const redactor = slowRedact({ paths: ['req,headers.cookie'] })
```

**After fix:**
```javascript
// Now correctly throws: Error: Invalid redaction path (req,headers.cookie)
const redactor = slowRedact({ paths: ['req,headers.cookie'] })
```

## Impact

This ensures slow-redact is a true drop-in replacement for fast-redact in projects like pino that rely on proper path validation.

🤖 Generated with [Claude Code](https://claude.ai/code)