### PR TITLE
chore: add missing `'use strict'` directives

### DIFF
--- a/benchmarks/basic.js
+++ b/benchmarks/basic.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { bench, group, run } = require('mitata')
 const slowRedact = require('../index.js')
 const fastRedact = require('fast-redact')

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('node:test')
 const { strict: assert } = require('node:assert')
 const slowRedact = require('../index.js')

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('node:test')
 const { strict: assert } = require('node:assert')
 const slowRedact = require('../index.js')

--- a/test/prototype-pollution.test.js
+++ b/test/prototype-pollution.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('node:test')
 const { strict: assert } = require('node:assert')
 const slowRedact = require('../index.js')

--- a/test/selective-clone.test.js
+++ b/test/selective-clone.test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const { test } = require('node:test')
 const { strict: assert } = require('node:assert')
 const slowRedact = require('../index.js')


### PR DESCRIPTION
Some of the cjs files have it and some don't, so made it consistent!