### PR TITLE
chore(.npmrc): ignore scripts

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+ignore-scripts=true
 package-lock=false


### PR DESCRIPTION
See https://github.com/fastify/deepmerge/pull/78, since Fastify and Pino are joined at the hip it makes sense to also implement this here.